### PR TITLE
Update ckeyon.rst

### DIFF
--- a/sphinx/source/C/ckeyon.rst
+++ b/sphinx/source/C/ckeyon.rst
@@ -4,7 +4,7 @@ CKEYON
 ======
 
 +----------+-------------------------------------------------------------------+
-| Syntax   |  CKEYON                                                           |
+| Syntax   |  CKEYON [#channel]                                                |
 +----------+-------------------------------------------------------------------+
 | Location |  Pointer Interface (v1.23 or later)                               |
 +----------+-------------------------------------------------------------------+
@@ -14,4 +14,7 @@ See :ref:`ckeyoff`.
 **NOTE**
 
 There were problems with this command prior to v1.56.
+
+In v2.06 if no channel number is given, and there is no default channel #0, a new 
+"ghost" channel is opened on every call to CKEYOFF or CKEYON.
 


### PR DESCRIPTION
There appears to be a bug in CKEYOFF/CKEYON: At some point they required a channel to be given. If none are, then the default channel is used (presumably #0) If no channel #0 is available (in the current instance of S*BASIC or compiled BASIC) then a channel #0 is opened. However, this is not added to the S*BASIC channel table, so each call to one of these commands opens a new channel in the main channel table.